### PR TITLE
Promise hooks in js - minor improvements

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -247,45 +247,34 @@ function restoreActiveHooks() {
 }
 
 function trackPromise(promise, parent, silent) {
-  const asyncId = getOrSetAsyncId(promise);
-
   if (parent) {
     promise[trigger_async_id_symbol] = getOrSetAsyncId(parent);
-    ObjectDefineProperty(promise, 'isChainedPromise', {
-      value: true
-    });
+    promise.isChainedPromise = true;
   } else {
     promise[trigger_async_id_symbol] = getDefaultTriggerAsyncId();
-    ObjectDefineProperty(promise, 'isChainedPromise', {
-      value: false
-    });
+    promise.isChainedPromise = false;
   }
 
+  const asyncId = getOrSetAsyncId(promise);
   if (!silent && initHooksExist()) {
     const triggerId = promise[trigger_async_id_symbol];
     emitInitScript(asyncId, 'PROMISE', triggerId, promise);
   }
 }
 
-function promiseHook(type, promise, parent) {
-  if (!promise) return;
+function fastPromiseHook(type, promise, parent) {
   if (type === 'init' || !promise[async_id_symbol]) {
     const silent = type !== 'init';
     if (parent instanceof Promise) {
-      if (!parent[async_id_symbol]) {
-        trackPromise(parent, null, true);
-      }
-
       trackPromise(promise, parent, silent);
     } else {
       trackPromise(promise, null, silent);
     }
+
+    if (!silent) return;
   }
 
-  if (!promise[async_id_symbol])
-    return;
-
-  const asyncId = getOrSetAsyncId(promise);
+  const asyncId = promise[async_id_symbol];
   switch (type) {
     case 'before':
       const triggerId = promise[trigger_async_id_symbol];
@@ -325,7 +314,7 @@ function updatePromiseHookMode() {
     }
   } else if (promiseHookMode !== 0) {
     promiseHookMode = 0;
-    enablePromiseHook(promiseHook);
+    enablePromiseHook(fastPromiseHook);
   }
 }
 


### PR DESCRIPTION
* Renames JS promise hook function to `fastPromiseHook`
* Removes `ObjectDefineProperty` usage as it seems to be a perf bottleneck
* Simplifies `fastPromiseHook` function to avoid redundant calls of `getOrSetAsyncId` and return as early as possible